### PR TITLE
chore: add build:ci smoke test to verify webpack build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,7 @@ jobs:
         run: npm run test
       - name: Build
         run: npm run build
+      - name: Build (CI)
+        run: npm run build:ci
       - name: i18n_extract
         run: npm run i18n_extract

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ build:
 	  done' sh {} +
 	tsc-alias -p tsconfig.build.json
 
+build-ci:
+	SITE_CONFIG_PATH=site.config.ci.tsx openedx build
+
 # turbo.site.json is the standalone turbo config for this package.  It is
 # renamed to avoid conflicts with turbo v2's workspace validation, which
 # rejects root task syntax (//#) and requires "extends" in package-level

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -20,7 +20,7 @@ window.open = (url, target, features) => {
   return originalWindowOpen(url, target, features);
 };
 
-const devApp: App = {
+export const devApp: App = {
   appId: 'notifications-dev-site',
   routes: [{
     path: '/',
@@ -39,5 +39,3 @@ const devApp: App = {
     element: <LinkMenuItem label="Home" url="/" variant="navLink" />,
   }],
 };
-
-export default devApp;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "build": "make build",
+    "build:ci": "make build-ci",
     "build:packages": "make build-packages",
     "clean": "make clean",
     "clean:packages": "make clean-packages",

--- a/site.config.ci.tsx
+++ b/site.config.ci.tsx
@@ -1,0 +1,24 @@
+import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
+
+import { notificationsApp } from './src';
+
+import '@openedx/frontend-base/shell/style';
+
+const siteConfig: SiteConfig = {
+  siteId: 'notifications-ci',
+  siteName: 'Notifications (CI)',
+  baseUrl: 'http://apps.local.openedx.io',
+  lmsBaseUrl: 'http://local.openedx.io',
+  loginUrl: 'http://local.openedx.io/login',
+  logoutUrl: 'http://local.openedx.io/logout',
+
+  environment: EnvironmentTypes.PRODUCTION,
+  apps: [
+    shellApp,
+    headerApp,
+    footerApp,
+    notificationsApp,
+  ],
+};
+
+export default siteConfig;

--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -6,8 +6,8 @@ import {
   shellApp,
 } from '@openedx/frontend-base';
 
-import notificationsApp from './src/app';
-import devApp from './dev';
+import { notificationsApp } from './src';
+import { devApp } from './dev';
 
 import '@openedx/frontend-base/shell/style';
 

--- a/site.config.test.tsx
+++ b/site.config.test.tsx
@@ -1,6 +1,6 @@
 import type { SiteConfig } from '@openedx/frontend-base';
 
-import notificationsApp from './src/app';
+import { notificationsApp } from './src';
 
 const siteConfig: SiteConfig = {
   siteId: 'notifications-test',


### PR DESCRIPTION
### Description

Apps are distributed build-less, so `npm run build` only compiles the library `dist/` via `tsc` and nothing in CI verifies that the app can actually be webpack-bundled as a deployable site. This PR adds an `npm run build:ci` script that exercises the real app graph through webpack, and wires it into the CI workflow after the existing build step.

Refs openedx/frontend-base#124.

### Verifying the check

Introduce a typo in an import somewhere in `src/` that is reached from the app's route/component graph (for example, rename a file import to a path that doesn't exist). `npm run build` still passes, but `npm run build:ci` fails with a module resolution error. Revert the typo and the build goes green again.

### LLM usage notice

Built with assistance from Claude.