### PR TITLE
fix: place desktop bell before the secondary-nav cluster

### DIFF
--- a/src/slots.tsx
+++ b/src/slots.tsx
@@ -7,7 +7,7 @@ const slots: SlotOperation[] = [
     slotId: 'org.openedx.frontend.slot.header.desktopRight.v1',
     id: `${appId}.widget.notificationsBell.desktop.v1`,
     op: WidgetOperationTypes.INSERT_BEFORE,
-    relatedId: 'org.openedx.frontend.widget.header.desktopAuthenticatedMenu.v1',
+    relatedId: 'org.openedx.frontend.widget.header.desktopSecondaryLinks.v1',
     element: <NotificationsTray />,
     condition: { authenticated: true },
   },


### PR DESCRIPTION
## Summary

Companion PR to openedx/frontend-base#251. Repositions the desktop notifications bell to render *before* the secondary-nav cluster instead of between it and the user avatar dropdown.

`relatedId` flips from `desktopAuthenticatedMenu` to `desktopSecondaryLinks`. With this change, the desktopRight cluster reads left-to-right as:
`[Bell, SecondaryNavLinks (incl. Help if configured), AuthenticatedMenu]`

Mobile is intentionally not changed — `mobileRight.v1` only contains the bell and auth menu (no secondary-nav cluster on mobile), so INSERT_BEFORE-the-mobile-auth-menu remains correct.

This PR targets the `frontend-base` branch to match where the rest of the help-button work lands.

## Test plan

- [ ] In a template-site dev with `commonAppConfig.SUPPORT_URL` set, navigate to a route that activates one of the dashboard apps and authenticate
- [ ] Verify desktop header reads `[primary nav | bell | secondary links incl. Help | avatar]` with the bell to the *left* of the help link
- [ ] Verify mobile right area still reads `[bell | avatar]` unchanged
- [ ] Click the bell — notifications tray opens as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)