### PR TITLE
fix: configure semantic-release to auto-publish the 2.x branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release CI
 on:
   push:
     branches:
-      - main
+      - 2.x
 
 permissions:
   contents: read # for checkout

--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,6 @@
 {
   "branches": [
-    "main"
+    "2.x"
   ],
   "tagFormat": "v${version}",
   "verifyConditions": [


### PR DESCRIPTION
### Description

Enables semantic-release to auto-publish the `2.x` maintenance line. Previously the release config listed only `main` as a release branch, so a run triggered on `2.x` would recognize the branch as unconfigured and skip publishing entirely.

This points the `.releaserc` `branches` entry and the release workflow trigger at `2.x`. Because the branch is named `N.x`, semantic-release classifies it as a maintenance branch with range `>=2.0.0 <3.0.0` and its own `2.x` channel, so it will pick up from the last v2 tag (`v2.0.11`) and cut the next patch/minor without touching the `latest` dist-tag, which continues to come from the `release` branch.

Note that this branch publishes under the pre-rename package name `@edx/frontend-plugin-notifications`, which is correct: that is the package the v2.x line has always shipped to, and it is independent of the renamed `@openedx/frontend-app-notifications` used by the 3.x line. semantic-release computes versions purely from git tags, so the differing package name does not affect version calculation. Publishing relies on npm trusted publishing, which is configured per package, so the old package needs a trusted-publisher entry for this repo and workflow.

The change is committed as a `fix:` so merging produces an actual `v2.0.12` release, validating the pipeline end to end.

### LLM usage notice

Built with assistance from Claude.